### PR TITLE
Do not fail to return embed when pob.party generation fails

### DIFF
--- a/poediscordbot/cogs/pob/pob_cog.py
+++ b/poediscordbot/cogs/pob/pob_cog.py
@@ -48,7 +48,7 @@ class PoBCog(commands.Cog):
             log.debug(f"A| {message.channel}: {message.content}")
             try:
                 xml, web_poe_token, paste_key = self._fetch_xml(message.author, message.content)
-                if xml and web_poe_token:
+                if xml:
                     embed = self._generate_embed(web_poe_token, xml, message.author, paste_key, minify=True)
                     if embed:
                         await message.channel.send(embed=embed)
@@ -63,7 +63,7 @@ class PoBCog(commands.Cog):
         if not self.allow_pming and ctx.message.channel.is_private:
             return
         xml, web_poe_token, paste_key = self._fetch_xml(ctx.message.author, ctx.message.content)
-        if xml and web_poe_token:
+        if xml:
             embed = self._generate_embed(web_poe_token, xml, ctx.message.author, paste_key)
             try:
                 if embed:

--- a/poediscordbot/pob_xml_parser/models/build.py
+++ b/poediscordbot/pob_xml_parser/models/build.py
@@ -67,7 +67,7 @@ class Build:
         try:
             self.stats[stat_owner][key] = float(val)
         except ValueError:
-            log.info(f"Unable to convert '{val}' to float.")
+            log.info(f"Unable to convert '{key}'='{val}' to float.")
 
     def append_conf(self, key, val):
         conf_entry = pob_conf.fetch_config_entry(key)


### PR DESCRIPTION
Token is already optional in embed generation do not check for it twice
(and do not make it required, when pob.party is outdated it will fail to
parse pob builds)

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>