### PR TITLE
Remove thresholds for max hits

### DIFF
--- a/poediscordbot/cogs/pob/output/aggregators/general_aggregator.py
+++ b/poediscordbot/cogs/pob/output/aggregators/general_aggregator.py
@@ -40,8 +40,7 @@ class GeneralAggregator(AbstractAggregator):
             max_hit_key = stat + 'MaximumHitTaken'
             max_hit_val = build.get_player_stat(max_hit_key, 0, 0)
             res_key = stat + 'DamageReduction' if stat == 'Physical' else stat + 'Resist'
-            res_threshold = OutputThresholds.CHAOS_RES.value if stat == 'Chaos' else OutputThresholds.ELE_RES.value
-            res_val = build.get_player_stat(res_key, res_threshold)
+            res_val = build.get_player_stat(res_key)
             if res_val:
                 output += "\n" + emojis[i] + f" {max_hit_val:,.0f} ({res_val:.0f}%)"
             show = True

--- a/poediscordbot/cogs/pob/poe_data/thresholds.py
+++ b/poediscordbot/cogs/pob/poe_data/thresholds.py
@@ -18,10 +18,6 @@ class OutputThresholds(Enum):
     ES_REGEN = 100
 
     WARD = 500
-    # Show ele res bigger than the 75 cap
-    ELE_RES = 76
-    # Show all positive chaos res
-    CHAOS_RES = 0
 
     # The amount below specifies the ratio of life to ev/ar: 100 life <> 80+ AR/EV is displayed
     AR_EV_THRESHOLD_PERCENTAGE = 0.8


### PR DESCRIPTION
They should always be displayed and this was breaking for builds with
75% max res.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>